### PR TITLE
Fix so that URI related params can be overwritten

### DIFF
--- a/src/ZohoReports/ZohoReports.php
+++ b/src/ZohoReports/ZohoReports.php
@@ -6,7 +6,7 @@ class ZohoReports
   /**
    * URI
    */
-  private $uri = 'https://reportsapi.zoho.com/api/';
+  protected $uri = 'https://reportsapi.zoho.com/api/';
 
   /**
    * Api version
@@ -102,7 +102,7 @@ class ZohoReports
    *
    * @return [array]
    */
-  private function setImportParams($params)
+  protected function setImportParams($params)
   {
     $default = [
       'format'       => 'CSV',
@@ -160,7 +160,7 @@ class ZohoReports
    * Build uri
    *
    */
-  private function buildUri()
+  protected function buildUri()
   {
     $uri = $this->uri
          . $this->email . '/'


### PR DESCRIPTION
The reasoning behind this PR is that Zoho in Europe uses a different API URL than in the US and hence the need for being able to override properties/method that were private before this fix (this fix makes them protected)